### PR TITLE
Use explicit workflow permissions where absent

### DIFF
--- a/.github/workflows/infersharp.yml
+++ b/.github/workflows/infersharp.yml
@@ -9,13 +9,15 @@ on:
   # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
+
     strategy:
       fail-fast: false
 

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -6,11 +6,14 @@ on:
   schedule:
     - cron: '15 0,12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - uses: EliahKagan/github-action-markdown-link-check@exclude-dir-experimental
-      with:
-        exclude-dirs: ./doc/bower_components
+      - uses: actions/checkout@v5
+      - uses: EliahKagan/github-action-markdown-link-check@exclude-dir-experimental
+        with:
+          exclude-dirs: ./doc/bower_components

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,6 +2,9 @@ name: Run ShellCheck
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
And improve stylistic consistency in the workflows.

Note that it is only the `markdown-links` and `shellcheck` workflows that lacked explicit permissions. (The top-level `permissions` key in the `infersharp` workflow is moved up from where it was in the only job of the workflow.)